### PR TITLE
Add values, additional example

### DIFF
--- a/docs/rules/strict-logical-expressions.md
+++ b/docs/rules/strict-logical-expressions.md
@@ -11,11 +11,11 @@ Examples of **incorrect** code for this rule:
 
 ```js
 // Potentially falsey strings are not allowed
-let str;
+let str = '';
 <App>{str && <Foo />}</App>;
 
 // Potentially falsey numbers are not allowed
-let num;
+let num = 0;
 <App>{num && <Foo />}</App>;
 
 // Includes types that may be a string or number
@@ -37,6 +37,10 @@ let str = "Foo";
 // Constant values are ok
 const str = "Foo";
 <App>{str && <Foo />}</App>;
+
+// Constant values are ok
+const num = 1;
+<App>{num && <Foo />}</App>;
 ```
 
 ### Options


### PR DESCRIPTION
Thanks for this plugin @hpersson, really cool! 🙌 I will include it in [our configuration for our bootcamp students](https://github.com/upleveled/eslint-config-upleveled)

Reading through the documentation here, it seems that these uninitialized variables do not actually raise warnings/errors with the plugin - they need to have a type of `number` or `string`, either by initializing with a value (like this PR does) or assigning a type.

Also added an example of a number constant that does not raise problems with the plugin.

If you want additional **incorrect** examples with a TS type annotation, I can add these as well.