### PR TITLE
Remove React Native links

### DIFF
--- a/docs/rules/strict-logical-expressions.md
+++ b/docs/rules/strict-logical-expressions.md
@@ -60,7 +60,5 @@ defaultOptions: [
 ## Further Reading
 
 - [React docs on conditional rendering](https://reactjs.org/docs/conditional-rendering.html#inline-if-with-logical--operator)
-- [Conditional rendering in React Native may crash your app](https://koprowski.it/2020/conditional-rendering-react-native-text-crash/)
 - https://github.com/facebook/react/blob/95a313ec0b957f71798a69d8e83408f40e76765b/packages/react-reconciler/src/ReactChildFiber.js#L461
 - https://github.com/yannickcr/eslint-plugin-react/issues/2073
-- https://github.com/facebook/react-native/issues/20764


### PR DESCRIPTION
Seems like React Native doesn't error out with empty strings anymore? https://twitter.com/karlhorky/status/1576958348288987137

Feel free to close if I'm wrong on this somehow. If I'm wrong, sorry for the noise!